### PR TITLE
Update gk-deploy

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -921,7 +921,7 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+heketi_pod=$(${CLI} get pod --no-headers --all-namespaces --selector="heketi" | awk '{print $1}')
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')


### PR DESCRIPTION
--show-all is depricated in kubernetes 1.15. Now we have to use --all-namespaces. I have fixed this in gk-deploy file.